### PR TITLE
feat(sync): IN-2561 Support queryOptions

### DIFF
--- a/lib/mysql.js
+++ b/lib/mysql.js
@@ -174,6 +174,19 @@ MySQL.prototype.executeSQL = function(sql, params, options, callback) {
   }
 
   var transaction = options.transaction;
+  var queryOptions = {
+    sql: sql,
+    values: params,
+  };
+
+  if (
+    'queryOptions' in options &&
+    options.queryOptions &&
+    typeof options.queryOptions === 'object'
+  ) {
+    Object.assign(queryOptions, options.queryOptions);
+    delete options.queryOptions;
+  }
 
   function handleResponse(connection, err, result) {
     if (!transaction) {
@@ -183,7 +196,7 @@ MySQL.prototype.executeSQL = function(sql, params, options, callback) {
   }
 
   function runQuery(connection, release) {
-    connection.query(sql, params, function(err, data) {
+    connection.query(queryOptions, function(err, data) {
       if (debugEnabled) {
         if (err) {
           debug('Error: %j', err);


### PR DESCRIPTION
## Problem/Description

In order to support returning json values from the loopback connector, we need to be able to provide the `typeCast` option to the `connection.query` function from `mysql`

## Solution

Add a `queryOptions` parameter to the loopback options object which gets assigned to the `queryOptions` object.