### PR TITLE
fix(connection): IN-2656 Remove default settings

### DIFF
--- a/lib/mysql.js
+++ b/lib/mysql.js
@@ -108,9 +108,6 @@ function generateOptions(settings) {
   if (s.collation) {
     // Charset should be first 'chunk' of collation.
     s.charset = s.collation.substr(0, s.collation.indexOf('_'));
-  } else {
-    s.collation = 'utf8_general_ci';
-    s.charset = 'utf8';
   }
 
   s.supportBigNumbers = (s.supportBigNumbers || false);


### PR DESCRIPTION
## Problem/Description

Loopback [specifies a default charset and collation](https://github.com/agriwebb/loopback-connector-mysql/blob/a3bf906de072d73764beefd08232235c0a03e2f8/lib/mysql.js#L112-L113) which is more restrictive than our tables. This causes a lossy conversion to occur in our connection converting characters like 🍌 to `?`. 